### PR TITLE
Fix typo bytesRead -> bytes

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -14,6 +14,7 @@ function read(buf, offset) {
   do {
     if(counter >= l) {
       read.bytes = 0
+      read.bytesRead = 0 // DEPRECATED
       return undefined
     }
     b = buf[counter++]

--- a/decode.js
+++ b/decode.js
@@ -10,10 +10,10 @@ function read(buf, offset) {
     , counter = offset
     , b
     , l = buf.length
-  
+
   do {
     if(counter >= l) {
-      read.bytesRead = 0
+      read.bytes = 0
       return undefined
     }
     b = buf[counter++]
@@ -22,8 +22,8 @@ function read(buf, offset) {
       : (b & REST) * Math.pow(2, shift)
     shift += 7
   } while (b >= MSB)
-  
+
   read.bytes = counter - offset
-  
+
   return res
 }

--- a/test.js
+++ b/test.js
@@ -126,6 +126,7 @@ test('buffer too short', function (assert) {
   while(l--) {
     var val = decode(buffer.slice(0, l))
     assert.equal(val, undefined)
+    assert.equal(decode.bytes, 0)
     assert.equal(decode.bytesRead, 0)
   }
   assert.end()


### PR DESCRIPTION
When decoding an invalid varint, `bytes` would be `undefined` instead of `0` as the documentation suggests due to a typo.