### PR TITLE
throw instead of returning undefined on error

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -15,7 +15,7 @@ function read(buf, offset) {
     if(counter >= l) {
       read.bytes = 0
       read.bytesRead = 0 // DEPRECATED
-      return undefined
+      throw new Error('Could not decode varint')
     }
     b = buf[counter++]
     res += shift < 28


### PR DESCRIPTION
This currently causes a deopt when parsing non-valid varints. I think an exception is a more appropriate (breaking change though).

This also fixes a bug in my protocol-buffers module that causes the CPU to spin at 100% when parsing invalid varints.
