### PR TITLE
Relax decode bounds check

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -12,7 +12,7 @@ function read(buf, offset) {
     , l = buf.length
 
   do {
-    if (counter >= l || shift > 49) {
+    if (counter >= l || shift > 64) {
       read.bytes = 0
       throw new RangeError('Could not decode varint')
     }


### PR DESCRIPTION
In https://github.com/chrisdickinson/varint/pull/20, a check was made to prevent maliciously crafted input from resulting in `NaN` or `Infinity` decoded values.

The check only allows varints with bitlength <= 48 to be decoded.
This is strict, perhaps _overly strict_. It disallows this library to decode varint64, an extremely common usecase. 

But this leads us to a difficult situation without a deeper and more invasive code change -- a tradeoff between allowing a useful range of input buffer lengths and ensuring correctness of all outputs:
1. If we disallow varints with bitlength > 49, we cannot support uvarint64, but we can guarantee the correctness of all outputs (as we simply disallow decoding values > Number.MAX_SAFE_INTEGER).
2. If we allow varints with bitlength > 49, we can support uvarint64, but we cannot guarantee the correctness of the output if the decoded value is > Number.MAX_SAFE_INTEGER.

https://github.com/chrisdickinson/varint/pull/20, was written with the intent of 1.

Talking with other teams who use this library, it seems that 2. is the more practical, useful.
cc @vasco-santos

This PR keeps the core check of https://github.com/chrisdickinson/varint/pull/20, but relaxes it to allow for varint64.