### PR TITLE
Update benchmark to solely measure the encode/decode time

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -30,7 +30,7 @@ var M = 10
   recomendation: return undefined
 */
 
-var buffer = new Buffer.alloc(8)
+var buffer = Buffer.alloc(8)
 var _buffer = buffer.slice(0, 4)
 var varint = require('./')
 var l = N


### PR DESCRIPTION
This change only measures around the actual `encode` and `decode` calls instead of the whole benchmark loop. This should make the benchmark more sensitive to changes in the  actual performance.