### PR TITLE
Make decode almost as efficient as encode

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -2,25 +2,24 @@ module.exports = read
 
 var MSB = 0x80
   , REST = 0x7F
+  , TWO_POWER_SEVEN = Math.pow(2, 7)
 
 function read(buf, offset) {
   var res    = 0
     , offset = offset || 0
-    , shift  = 0
+    , shift  = 1
     , counter = offset
     , b
-    , l = buf.length
+    , l = Math.pow(TWO_POWER_SEVEN, buf.length - offset < 8 ? (buf.length - offset) * 7 : 49)
 
   do {
-    if (counter >= l || shift > 49) {
+    if (shift > l) {
       read.bytes = 0
       throw new RangeError('Could not decode varint')
     }
     b = buf[counter++]
-    res += shift < 28
-      ? (b & REST) << shift
-      : (b & REST) * Math.pow(2, shift)
-    shift += 7
+    res += (b & REST) * shift
+    shift = shift * TWO_POWER_SEVEN
   } while (b >= MSB)
 
   read.bytes = counter - offset


### PR DESCRIPTION
This improves the performance of the `decode` function using the following listed changes.

- Calculate 2^7 exactly once instead of using `Math.pow` on every loop past 27 bytes
- Use `shift` directly as a multiplier instead of an exponent, multiplying by 2^7 on each iteration
- Remove conditional check for previous optimization for values below 28 bytes
- Overload iteration-limiting values into variable `l`:
  - Reduce value from total buffer length based on previous `shift` limit (8 bytes)
  - Use as power of 2 so it can be directly compared with updated `shift` usage w/o conversions

Old code using #22 benchmark:
```
decode/ms, invalidDecodes
2417.21053903795, 0
```

New code using #22 benchmark:
```
decode/ms, invalidDecodes
12804.097311139565, 0
```